### PR TITLE
Modified for multiple I2C busses

### DIFF
--- a/I2C_Anything.h
+++ b/I2C_Anything.h
@@ -1,21 +1,35 @@
 // Written by Nick Gammon
 // May 2012
+// Jan 2022 Rev by Frank Paynter to accomodate multiple I2C busses
 
 #include <Arduino.h>
-#include <Wire.h>
+#include <Wire.h> //07/06/20 chg back for I2C hangup testing
 
-template <typename T> unsigned int I2C_writeAnything (const T& value)
+template <typename T> unsigned int I2C_writeAnything (const T& value, void *wireObj = 0)
   {
-  Wire.write((byte *) &value, sizeof (value));
-  return sizeof (value);
+
+  //01/20/22 allow use of Wire1, Wire2, etc
+  TwoWire* useWire = &Wire; //default is 'original' Wire
+  if (wireObj) useWire = (TwoWire*)wireObj;//use this if a non-zero addr was supplied
+  const byte * p = (const byte*) &value;
+    unsigned int i;
+    for (i = 0; i < sizeof value; i++)
+      useWire->write(*p++);
+
+    return i;
   }  // end of I2C_writeAnything
 
-template <typename T> unsigned int I2C_readAnything(T& value)
+template <typename T> unsigned int I2C_readAnything(T& value, TwoWire* wireObj = 0)
   {
+  //01/20/22 allow use of Wire1, Wire2, etc
+  TwoWire* useWire = &Wire; //default is 'original' Wire
+  if (wireObj) useWire = (TwoWire*)wireObj;//use this if a non-zero addr was supplied
+
     byte * p = (byte*) &value;
     unsigned int i;
     for (i = 0; i < sizeof value; i++)
-          *p++ = Wire.read();
+          *p++ = useWire->read();
+
     return i;
   }  // end of I2C_readAnything
 


### PR DESCRIPTION
I use the I2C_Anything library frequently for my Arduino and Teensy projects, but recently discovered it doesn't allow for the use of multiple I2C busses.  I stole the multi-bus code from Kurt E's multiple-I2C-bus capable MPU6050 library and used it to make I2C_Anything multi-bus compatible